### PR TITLE
Wim compressed stream

### DIFF
--- a/dissect/archive/wim.py
+++ b/dissect/archive/wim.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import io
-import struct
-from functools import cached_property, lru_cache
-from typing import TYPE_CHECKING, BinaryIO, Callable
+from functools import cached_property
+from typing import TYPE_CHECKING, BinaryIO
 
-from dissect.util.stream import AlignedStream, BufferedStream, RelativeStream
+from dissect.util.stream import BufferedStream, CompressedStream, RelativeStream
 from dissect.util.ts import wintimestamp
 
 from dissect.archive.c_wim import (
@@ -426,74 +425,6 @@ class ReparsePoint:
             return False
 
         return self.info.Flags == SYMLINK_FLAG.RELATIVE
-
-
-class CompressedStream(AlignedStream):
-    def __init__(
-        self,
-        fh: BinaryIO,
-        offset: int,
-        compressed_size: int,
-        original_size: int,
-        decompressor: Callable[[bytes], bytes],
-        chunk_size: int = DEFAULT_CHUNK_SIZE,
-    ):
-        self.fh = fh
-        self.offset = offset
-        self.compressed_size = compressed_size
-        self.original_size = original_size
-        self.decompressor = decompressor
-        self.chunk_size = chunk_size
-
-        # Read the chunk table in advance
-        fh.seek(self.offset)
-        num_chunks = (original_size + self.chunk_size - 1) // self.chunk_size - 1
-        if num_chunks == 0:
-            self._chunks = (0,)
-        else:
-            entry_size = "Q" if original_size > 0xFFFFFFFF else "I"
-            pattern = f"<{num_chunks}{entry_size}"
-            self._chunks = (0, *struct.unpack(pattern, fh.read(struct.calcsize(pattern))))
-
-        self._data_offset = fh.tell()
-
-        self._read_chunk = lru_cache(32)(self._read_chunk)
-        super().__init__(self.original_size)
-
-    def _read(self, offset: int, length: int) -> bytes:
-        result = []
-
-        num_chunks = len(self._chunks)
-        chunk, offset_in_chunk = divmod(offset, self.chunk_size)
-
-        while length:
-            if chunk >= num_chunks:
-                # We somehow requested more data than we have runs for
-                break
-
-            chunk_offset = self._chunks[chunk]
-            if chunk < num_chunks - 1:
-                next_chunk_offset = self._chunks[chunk + 1]
-                chunk_remaining = self.chunk_size - offset_in_chunk
-            else:
-                next_chunk_offset = self.compressed_size
-                chunk_remaining = (self.original_size - (chunk * self.chunk_size)) - offset_in_chunk
-
-            read_length = min(chunk_remaining, length)
-
-            buf = self._read_chunk(chunk_offset, next_chunk_offset - chunk_offset)
-            result.append(buf[offset_in_chunk : offset_in_chunk + read_length])
-
-            length -= read_length
-            offset += read_length
-            chunk += 1
-
-        return b"".join(result)
-
-    def _read_chunk(self, offset: int, size: int) -> bytes:
-        self.fh.seek(self._data_offset + offset)
-        buf = self.fh.read(size)
-        return self.decompressor(buf)
 
 
 def _ts_to_ns(ts: int) -> int:

--- a/dissect/archive/wim.py
+++ b/dissect/archive/wim.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import struct
 from functools import cached_property
 from typing import TYPE_CHECKING, BinaryIO
 
@@ -83,10 +84,10 @@ class Resource:
         "flags",
         "hash",
         "offset",
-        "original_size",
+        "original_size", # uncompressed size of the resource
         "part_number",
         "reference_count",
-        "size",
+        "size",  # Compressed size of the resource
         "wim",
     )
 
@@ -150,7 +151,7 @@ class Resource:
             decompressor = DECOMPRESSOR_MAP.get(compression_flags)
             if decompressor is None:
                 raise NotImplementedError(f"Compression algorithm not yet supported: {compression_flags}")
-            return CompressedStream(
+            return WimCompressedStream(
                 self.wim.fh, self.offset, self.size, self.original_size, decompressor, self.wim.header.CompressionSize
             )
 
@@ -434,3 +435,53 @@ def _ts_to_ns(ts: int) -> int:
 
 def _read_name(fh: BinaryIO, length: int) -> str:
     return fh.read(length).decode("utf-16-le")
+
+
+class WimCompressedStream(CompressedStream):
+    """Compressed stream for Windows Imaging (WIM) archives. This class handles the decompression of WIM archives
+    using the specified decompressor.
+
+    Supported decompression methods are currently:
+        * LZXPRESS4K Huffman
+        * LZXPRESS8K Huffman
+        * LZXPRESS16K Huffman
+        * LZXPRESS32K Huffman (default)
+
+    Note that LZX decompression is not yet supported.
+
+    Args:
+        fh: A file-like object for the compressed data.
+        offset: The offset to the start of the chunk table.
+        size: The size of the compressed data.
+        original_size: The original size of the uncompressed data.
+        decompress: The decompressor function to use.
+        chunk_size: The size of the chunks to read from the compressed data. (default: 32 KiB)
+    """
+
+    def __init__(
+        self,
+        fh: BinaryIO,
+        offset: int,
+        size: int,
+        original_size: int,
+        decompress: callable,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+    ):
+        fh.seek(offset)
+        num_chunks = (original_size + chunk_size - 1) // chunk_size - 1
+
+        entry_size = "Q" if original_size > 0xFFFFFFFF else "I"
+        pattern = f"<{num_chunks}{entry_size}"
+        chunks = (0, *struct.unpack(pattern, fh.read(struct.calcsize(pattern))))
+
+        super().__init__(fh, fh.tell(), size, original_size, decompress, chunk_size, chunks)
+
+    def _read_chunk(self, offset: int, size: int) -> bytes:
+        self.fh.seek(self.offset + offset)
+        buf = self.fh.read(size)
+
+        uncompressed_size = (
+            ((self.original_size - 1) & (self.chunk_size - 1)) + 1 if offset == self.chunks[-1] else self.chunk_size
+        )
+
+        return buf if len(buf) == uncompressed_size else self.decompressor(buf)

--- a/tests/_data/lzms.wim.gz
+++ b/tests/_data/lzms.wim.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee11028e1362c5eee73b53daf2bd7c8401594681ad057165a2723d451e29a015
+size 1259

--- a/tests/_data/lzx.wim.gz
+++ b/tests/_data/lzx.wim.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96ed547a8a87537968e7ef86e7fa147030cee8efa4b4a73c47eb08b0c56c9adb
+size 1309

--- a/tests/_data/uncompressed.wim.gz
+++ b/tests/_data/uncompressed.wim.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2c6e7e99cc63ce264d67efcdce5d8357c0f17670f8f58fd04db6c930c586a89
+size 1089

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,21 @@ def open_file_gz(name: str, mode: str = "rb") -> Iterator[BinaryIO]:
 
 
 @pytest.fixture
+def uncompressed_wim() -> Iterator[BinaryIO]:
+    yield from open_file_gz("_data/uncompressed.wim.gz")
+
+
+@pytest.fixture
+def lzms_wim() -> Iterator[BinaryIO]:
+    yield from open_file_gz("_data/lzms.wim.gz")
+
+
+@pytest.fixture
+def lzx_wim() -> Iterator[BinaryIO]:
+    yield from open_file_gz("_data/lzx.wim.gz")
+
+
+@pytest.fixture
 def basic_wim_4k() -> Iterator[BinaryIO]:
     yield from open_file_gz("_data/basic4k.wim.gz")
 

--- a/tests/test_wim.py
+++ b/tests/test_wim.py
@@ -16,19 +16,24 @@ from dissect.archive.wim import WIM, CompressedStream
         ("basic_wim_8k", 0x2000),
         ("basic_wim_16k", 0x4000),
         ("basic_wim_32k", 0x8000),
+        ("uncompressed_wim", 0),
     ],
 )
 def test_wim(fixture: BinaryIO, chunk_size: int, request: pytest.FixtureRequest) -> None:
     value = request.getfixturevalue(fixture)
     wim = WIM(value)
+
     assert wim.header.CompressionSize == chunk_size
 
-    resource = next(iter(wim.resources.values()))
-    assert resource.open().chunk_size == chunk_size
+    if chunk_size:
+        resource = next(iter(wim.resources.values()))
+        assert resource.open().chunk_size == chunk_size
 
-    stream = CompressedStream(wim.fh, resource.offset, resource.size, resource.original_size, decompress, chunk_size)
-    assert resource.wim.header.CompressionSize == stream.chunk_size
-    assert resource.open().read() == stream.read()
+        stream = CompressedStream(
+            wim.fh, resource.offset, resource.size, resource.original_size, decompress, chunk_size
+        )
+        assert resource.wim.header.CompressionSize == stream.chunk_size
+        assert resource.open().read() == stream.read()
 
     images = list(wim.images())
     assert len(images) == 1

--- a/tests/test_wim.py
+++ b/tests/test_wim.py
@@ -6,7 +6,7 @@ from typing import BinaryIO
 import pytest
 from dissect.util.compression.lzxpress_huffman import decompress
 
-from dissect.archive.wim import WIM, CompressedStream
+from dissect.archive.wim import WIM, WimCompressedStream
 
 
 @pytest.mark.parametrize(
@@ -29,7 +29,7 @@ def test_wim(fixture: BinaryIO, chunk_size: int, request: pytest.FixtureRequest)
         resource = next(iter(wim.resources.values()))
         assert resource.open().chunk_size == chunk_size
 
-        stream = CompressedStream(
+        stream = WimCompressedStream(
             wim.fh, resource.offset, resource.size, resource.original_size, decompress, chunk_size
         )
         assert resource.wim.header.CompressionSize == stream.chunk_size
@@ -79,3 +79,17 @@ def test_wim(fixture: BinaryIO, chunk_size: int, request: pytest.FixtureRequest)
     assert len(entry.streams) == 1
     assert entry.size() == 60
     assert hashlib.sha1(entry.open().read()).hexdigest() == "1fc83a896287fe48f6d42d8d04f88f6dc90c0c45"
+
+
+@pytest.mark.parametrize(
+    ("fixture"),
+    [
+        ("lzms_wim"),
+        ("lzx_wim"),
+    ],
+)
+def test_wim_not_implemented(fixture: BinaryIO, request: pytest.FixtureRequest) -> None:
+    data = request.getfixturevalue(fixture)
+
+    with pytest.raises(NotImplementedError):
+        WIM(data)._images[0].open()


### PR DESCRIPTION
This PR adds a dedicated WimCompressedStream based on the previous CompressedStream class which is due to be moved to dissect.util.

Some additional tests have been added to account for unsupported compression methods and uncompressed WIM archives.

Depends on #14 